### PR TITLE
Add must helper funcs

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,58 +27,64 @@ Get an env var value. If the value does not exist, an error will be
 returned:
 
 #+BEGIN_EXAMPLE
-val, err := envlookup.String("JAZZ_ARTIST")
+s, err := envlookup.String("JAZZ_ARTIST")
 #+END_EXAMPLE
 
 *** Get env or default value
 
 Get an env var value or a default value if it does not exist:
 #+BEGIN_EXAMPLE
-val, err := envlookup.String("JAZZ_SAXOPHONIST", "Wayne Shorter")
+s, err := envlookup.String("JAZZ_SAXOPHONIST", "Wayne Shorter")
+#+END_EXAMPLE
+
+*** Get mandatory env
+There are must helper functions for mandatory env vars (panics if err is non-nil):
+#+BEGIN_EXAMPLE
+s := envlookup.MustString(envlookup.String("JAZZ_SAXOPHONIST"))
 #+END_EXAMPLE
 
 *** Get slice env
 
 To get values as a slice (comma-separated string):
 #+BEGIN_EXAMPLE
-val, err := envlookup.Slice("RECORD_LABELS")
+s, err := envlookup.Slice("RECORD_LABELS")
 #+END_EXAMPLE
 
 *** Get bool env
 
 Boolean values are supported:
 #+BEGIN_EXAMPLE
-val, err := envlookup.Bool("PLAYED_WITH_MILES_DAVIES")
+b, err := envlookup.Bool("PLAYED_WITH_MILES_DAVIES")
 #+END_EXAMPLE
 
 *** Get float or int env
 
 Get float (64 bit) or int envs:
 #+BEGIN_EXAMPLE
-val, err := envlookup.Int("NO_OF_STUDIO_ALBUMS")
+i, err := envlookup.Int("NO_OF_STUDIO_ALBUMS")
 #+END_EXAMPLE
 
 *** Get duration env
 
 To get a duration value:
 #+BEGIN_EXAMPLE
-val, err := envlookup.Duration("LONGEST_RECORDED_TRACK")
+d, err := envlookup.Duration("LONGEST_RECORDED_TRACK")
 #+END_EXAMPLE
 
 *** Errors
 If an env var is not set (and there is no default value set), a NotFoundError will be returned:
 #+BEGIN_EXAMPLE
-val, err := envlookup.Duration("COUNTRY_ARTIST")
+d, err := envlookup.Duration("LONGEST_ALBUM")
 if _, ok := err.(*envlookup.NotFoundError); ok {
     log.Println(err)
-    // could not find environment variable "COUNTRY_ARTIST"
+    // could not find environment variable "LONGEST_ALBUM"
     ...
 }
 #+END_EXAMPLE
 
 If an env var can not be parsed as the expected return type, a ParseError will be returned:
 #+BEGIN_EXAMPLE
-val, err := envlookup.Float64("LONGEST_RECORDED_TRACK")
+f, err := envlookup.Float64("LONGEST_RECORDED_TRACK")
 if _, ok := err.(*envlookup.ParseError); ok {
     log.Println(err)
     // could not parse environment variable "LONGEST_RECORDED_TRACK": strconv.ParseFloat: parsing "27m32s": invalid syntax

--- a/envlookup_test.go
+++ b/envlookup_test.go
@@ -343,6 +343,7 @@ func TestBoolStrParse(t *testing.T) {
 
 func TestIntEnvFormatErr(t *testing.T) {
 	os.Setenv("NO_OF_STUDIO_ALBUMS", "ABC")
+	defer setVars()
 	defval := 1
 	val, err := envlookup.Int("NO_OF_STUDIO_ALBUMS", defval)
 	if val == defval {

--- a/must.go
+++ b/must.go
@@ -1,0 +1,69 @@
+package envlookup
+
+import "time"
+
+// MustBool is a helper that wraps a call to a function returning
+// (bool, error) and panics if the error is non-nil. It is intended for
+// use such as
+//	b := envlookup.MustBool(envlookup.Bool("key"))
+func MustBool(b bool, err error) bool {
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// MustDuration is a helper that wraps a call to a function returning
+// (time.Duration, error) and panics if the error is non-nil. It is
+// intended for use such as
+//	d := envlookup.MustDuration(envlookup.Duration("key"))
+func MustDuration(d time.Duration, err error) time.Duration {
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+// MustFloat64 is a helper that wraps a call to a function returning
+// (float64, error) and panics if the error is non-nil. It is intended
+// for use such as
+//	f := envlookup.MustFloat64(envlookup.Float64("key"))
+func MustFloat64(f float64, err error) float64 {
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// MustInt is a helper that wraps a call to a function returning
+// (int, error) and panics if the error is non-nil. It is intended for
+// use such as
+//	i := envlookup.MustInt(envlookup.Int("key"))
+func MustInt(i int, err error) int {
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// MustSlice is a helper that wraps a call to a function returning
+// ([]string, error) and panics if the error is non-nil. It is intended
+// for use such as
+//	s := envlookup.MustSlice(envlookup.Slice("key"))
+func MustSlice(s []string, err error) []string {
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// MustString is a helper that wraps a call to a function returning
+// (string, error) and panics if the error is non-nil. It is intended
+// for use such as
+//	s := envlookup.MustString(envlookup.String("key"))
+func MustString(s string, err error) string {
+	if err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/must_test.go
+++ b/must_test.go
@@ -1,0 +1,144 @@
+package envlookup_test
+
+import (
+	"testing"
+
+	"github.com/spider-pigs/envlookup"
+)
+
+func TestMustBool(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Function call should not panic")
+		}
+	}()
+	b := envlookup.MustBool(envlookup.Bool("PLAYED_WITH_MILES_DAVIES"))
+	if !b {
+		t.Error("value should not be false", b)
+	}
+}
+
+func TestMustBoolPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Function call should panic")
+		}
+	}()
+
+	envlookup.MustBool(envlookup.Bool("PANIC_PLEASE"))
+}
+
+func TestMustDuration(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Function call should not panic")
+		}
+	}()
+
+	d := envlookup.MustDuration(envlookup.Duration("LONGEST_RECORDED_TRACK"))
+	if d == 0 {
+		t.Error("value should not be zero", d)
+	}
+}
+
+func TestMustDurationPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Function call should panic")
+		}
+	}()
+
+	envlookup.MustBool(envlookup.Bool("LONGEST_RECORDED_TRACK_FLOAT"))
+}
+
+func TestMustFloat64(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Function call should not panic")
+		}
+	}()
+
+	f := envlookup.MustFloat64(envlookup.Float64("LONGEST_RECORDED_TRACK_FLOAT"))
+	if f == 0 {
+		t.Error("value should not be zero", f)
+	}
+}
+
+func TestMustFloat64Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Function call should panic")
+		}
+	}()
+
+	envlookup.MustFloat64(envlookup.Float64("PANIC_PLEASE"))
+}
+
+func TestMustInt(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Function call should not panic")
+		}
+	}()
+
+	i := envlookup.MustInt(envlookup.Int("NO_OF_STUDIO_ALBUMS"))
+	if i == 0 {
+		t.Error("value should not be zero", i)
+	}
+}
+
+func TestMustIntPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Function call should panic")
+		}
+	}()
+
+	envlookup.MustInt(envlookup.Int("PANIC_PLEASE"))
+}
+
+func TestMustSlice(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Function call should not panic")
+		}
+	}()
+
+	s := envlookup.MustSlice(envlookup.Slice("RECORD_LABELS"))
+	if len(s) == 0 {
+		t.Error("value should not be zero", s)
+	}
+}
+
+func TestMustSlicePanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Function call should panic")
+		}
+	}()
+
+	envlookup.MustSlice(envlookup.Slice("PANIC_PLEASE"))
+}
+
+func TestMustString(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Function call should not panic")
+		}
+	}()
+
+	s := envlookup.MustString(envlookup.String("JAZZ_ARTIST"))
+	if len(s) == 0 {
+		t.Error("value should be returned", s)
+	}
+}
+
+func TestMustStringPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Function call should panic")
+		}
+	}()
+
+	envlookup.MustString(envlookup.String("PANIC_PLEASE"))
+}


### PR DESCRIPTION
Add helper functions that follows golang must pattern. The
functions will panic if an error is non-nil.

```
s := envlookup.MustString(envlookup.String("key"))
```